### PR TITLE
Implement schedule overlays and booking UX improvements

### DIFF
--- a/Secretariat/templates/availability.html
+++ b/Secretariat/templates/availability.html
@@ -10,11 +10,11 @@
       available and unavailable time slots.
     </p>
 
-    <form class="section" method="get">
+    <form id="schedule-controls" class="section" method="get" action="{{ url_for('schedule') }}">
       <div class="form-grid">
         <label class="field">
           <span class="field-label">Business</span>
-          <select name="business_id">
+          <select id="business-select" name="business_id">
             {% for business in businesses %}
               <option value="{{ business.id }}" {% if business.id == selected_business.id %}selected{% endif %}>
                 {{ business.name }}
@@ -25,7 +25,7 @@
 
         <label class="field">
           <span class="field-label">Service</span>
-          <select name="service_id">
+          <select id="service-select" name="service_id">
             {% for service in selected_business.services %}
               <option value="{{ service.id }}" {% if service.id == selected_service.id %}selected{% endif %}>
                 {{ service.name }} ({{ service.duration }} min)
@@ -37,6 +37,7 @@
         <label class="field">
           <span class="field-label">Date</span>
           <input
+            id="schedule-date"
             type="date"
             name="date"
             value="{{ selected_date }}"
@@ -46,11 +47,13 @@
       </div>
 
       <div class="section">
-        <button type="submit" class="button">Update Appointment Options</button>
+        <button id="schedule-update-button" type="submit" class="button">
+          Update Appointment Options
+        </button>
       </div>
     </form>
 
-    <div class="business-grid section">
+    <div id="business-grid" class="business-grid section">
       {% for business in businesses %}
         <article class="business-card{% if business.id == selected_business.id %} is-selected{% endif %}">
           <header class="business-head">
@@ -68,22 +71,23 @@
     </div>
   </section>
 
-  <section class="panel section">
-    <h2>{{ selected_business.name }}</h2>
-    <p class="calendar-meta">
+  <section id="schedule-detail-panel" class="panel section">
+    <h2 id="selected-business-title">{{ selected_business.name }}</h2>
+    <p id="selected-service-meta" class="calendar-meta">
       {{ selected_service.name }} · {{ selected_service.duration }} minutes ·
       Time range {{ selected_time_range }}
     </p>
-    <p class="calendar-meta">
+    <p id="selected-date-meta" class="calendar-meta">
       {{ selected_date_human }} · {{ available_count }} available ·
       {{ unavailable_count }} unavailable
     </p>
 
-    <div class="day-strip section">
+    <div id="day-strip" class="day-strip section">
       {% for day in week_days %}
         <a
           class="day-pill day-pill--{{ day.status }}{% if day.is_selected %} is-selected{% endif %}"
           href="{{ url_for('schedule', business_id=selected_business.id, service_id=selected_service.id, date=day.date) }}"
+          data-date="{{ day.date }}"
         >
           <span class="day-pill-weekday">{{ day.weekday }}</span>
           <span class="day-pill-day">{{ day.day_number }}</span>
@@ -92,28 +96,453 @@
       {% endfor %}
     </div>
 
-    <div class="slot-legend section">
-      <span class="legend-item"><span class="legend-dot legend-dot--open"></span>Open</span>
-      <span class="legend-item"><span class="legend-dot legend-dot--limited"></span>Limited</span>
-      <span class="legend-item"><span class="legend-dot legend-dot--full"></span>Full</span>
-      <span class="legend-item"><span class="legend-dot legend-dot--closed"></span>Closed</span>
+    <section class="next-slot-panel section">
+      <h3 class="next-slot-title">Next 3 available times</h3>
+      <div id="next-slot-body">
+        {% if next_available_slots %}
+          <div class="next-slot-list">
+            {% for next_slot in next_available_slots %}
+              <p class="next-slot-item">
+                <strong>{{ next_slot.day_label }}</strong> · {{ next_slot.time_label }}
+              </p>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="next-slot-empty">
+            No open slots remain this week for the selected service.
+          </p>
+        {% endif %}
+      </div>
+    </section>
+
+    <section
+      id="timeline-panel"
+      class="timeline-panel section{% if not day_slots %} is-hidden{% endif %}"
+      aria-label="Availability overlay"
+    >
+      <h3 class="timeline-title">Availability Overlay</h3>
+      <div class="timeline-row">
+        <p class="timeline-label">Business</p>
+        <div id="timeline-business-cells" class="timeline-cells">
+          {% for slot in day_slots %}
+            <span
+              class="timeline-cell {% if slot.business_free %}is-free{% else %}is-busy{% endif %}"
+              title="{{ slot.label }}"
+            ></span>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="timeline-row">
+        <p class="timeline-label">You</p>
+        <div id="timeline-user-cells" class="timeline-cells">
+          {% for slot in day_slots %}
+            <span
+              class="timeline-cell {% if slot.user_free %}is-free{% else %}is-busy{% endif %}"
+              title="{{ slot.label }}"
+            ></span>
+          {% endfor %}
+        </div>
+      </div>
+    </section>
+
+    <div id="slot-legend" class="slot-legend section{% if not day_slots %} is-hidden{% endif %}">
+      <span class="legend-item">
+        <span class="legend-dot legend-dot--slot-available"></span>
+        Available (both free)
+      </span>
+      <span class="legend-item">
+        <span class="legend-dot legend-dot--slot-user-busy"></span>
+        Unavailable - You are busy
+      </span>
+      <span class="legend-item">
+        <span class="legend-dot legend-dot--slot-business-busy"></span>
+        Unavailable - Business is busy
+      </span>
+      <span class="legend-item">
+        <span class="legend-dot legend-dot--slot-both-busy"></span>
+        Unavailable - Both busy
+      </span>
     </div>
 
-    {% if day_slots %}
-      <div class="demo-slot-grid section">
-        {% for slot in day_slots %}
+    <div id="slot-grid" class="demo-slot-grid section{% if not day_slots %} is-hidden{% endif %}">
+      {% for slot in day_slots %}
+        {% if slot.bookable %}
+          <form class="inline-form" method="post" action="{{ url_for('book_appointment') }}">
+            <input type="hidden" name="business_id" value="{{ selected_business.id }}" />
+            <input type="hidden" name="service_id" value="{{ selected_service.id }}" />
+            <input type="hidden" name="date" value="{{ selected_date }}" />
+            <input type="hidden" name="slot_start" value="{{ slot.start_time }}" />
+            <button class="demo-slot is-available" type="submit">
+              <span>{{ slot.label }}</span>
+              <small>{{ slot.status_label }}</small>
+            </button>
+          </form>
+        {% else %}
           <button
-            class="demo-slot{% if slot.available %} is-available{% else %} is-unavailable{% endif %}"
+            class="demo-slot is-unavailable is-{{ slot.reason | replace('_', '-') }}"
             type="button"
-            {% if not slot.available %}disabled{% endif %}
+            disabled
           >
             <span>{{ slot.label }}</span>
-            <small>{{ slot.status }}</small>
+            <small>{{ slot.status_label }}</small>
           </button>
-        {% endfor %}
-      </div>
-    {% else %}
-      <p class="section">This business is closed on the selected day.</p>
-    {% endif %}
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <p id="closed-message" class="section{% if day_slots %} is-hidden{% endif %}">
+      This business is closed on the selected day.
+    </p>
   </section>
+
+  <script>
+    (() => {
+      const scheduleDataUrl = "{{ url_for('schedule_data') }}";
+      const scheduleUrl = "{{ url_for('schedule') }}";
+      const bookAppointmentUrl = "{{ url_for('book_appointment') }}";
+      const fallbackToday = "{{ today }}";
+      const businesses = {{ businesses | tojson }};
+
+      const controlsForm = document.getElementById("schedule-controls");
+      const updateButton = document.getElementById("schedule-update-button");
+      const businessSelect = document.getElementById("business-select");
+      const serviceSelect = document.getElementById("service-select");
+      const dateInput = document.getElementById("schedule-date");
+      const businessGrid = document.getElementById("business-grid");
+
+      const detailPanel = document.getElementById("schedule-detail-panel");
+      const selectedBusinessTitle = document.getElementById("selected-business-title");
+      const selectedServiceMeta = document.getElementById("selected-service-meta");
+      const selectedDateMeta = document.getElementById("selected-date-meta");
+      const dayStrip = document.getElementById("day-strip");
+      const nextSlotBody = document.getElementById("next-slot-body");
+      const timelinePanel = document.getElementById("timeline-panel");
+      const timelineBusinessCells = document.getElementById("timeline-business-cells");
+      const timelineUserCells = document.getElementById("timeline-user-cells");
+      const slotLegend = document.getElementById("slot-legend");
+      const slotGrid = document.getElementById("slot-grid");
+      const closedMessage = document.getElementById("closed-message");
+
+      if (
+        !controlsForm
+        || !businessSelect
+        || !serviceSelect
+        || !dateInput
+        || !businessGrid
+        || !detailPanel
+        || !selectedBusinessTitle
+        || !selectedServiceMeta
+        || !selectedDateMeta
+        || !dayStrip
+        || !nextSlotBody
+        || !timelinePanel
+        || !timelineBusinessCells
+        || !timelineUserCells
+        || !slotLegend
+        || !slotGrid
+        || !closedMessage
+      ) {
+        return;
+      }
+
+      let inFlightController = null;
+
+      const escapeHtml = (value) =>
+        String(value)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+
+      const queryStringFor = (state) =>
+        new URLSearchParams(state).toString();
+
+      const getBusinessById = (businessId) =>
+        businesses.find((business) => business.id === businessId)
+        || businesses[0];
+
+      const renderServiceOptions = (businessId, selectedServiceId) => {
+        const selectedBusiness = getBusinessById(businessId);
+        const fallbackServiceId = selectedBusiness.services[0]?.id || "";
+        const serviceExists = selectedBusiness.services.some(
+          (service) => service.id === selectedServiceId,
+        );
+        const resolvedServiceId = serviceExists
+          ? selectedServiceId
+          : fallbackServiceId;
+
+        serviceSelect.innerHTML = selectedBusiness.services
+          .map(
+            (service) =>
+              `<option value="${escapeHtml(service.id)}"${service.id === resolvedServiceId ? " selected" : ""}>`
+              + `${escapeHtml(service.name)} (${escapeHtml(service.duration)} min)</option>`,
+          )
+          .join("");
+        serviceSelect.value = resolvedServiceId;
+        return resolvedServiceId;
+      };
+
+      const renderBusinessCards = (selectedBusinessId) => {
+        businessGrid.innerHTML = businesses
+          .map((business) => {
+            const selectedClass = business.id === selectedBusinessId
+              ? " is-selected"
+              : "";
+            const serviceItems = business.services
+              .map(
+                (service) =>
+                  `<li>${escapeHtml(service.name)} (${escapeHtml(service.duration)} min)</li>`,
+              )
+              .join("");
+            return (
+              `<article class="business-card${selectedClass}">`
+              + `<header class="business-head">`
+              + `<h3 class="business-name">${escapeHtml(business.name)}</h3>`
+              + `<p class="business-location">${escapeHtml(business.location)}</p>`
+              + `</header>`
+              + `<p>${escapeHtml(business.description)}</p>`
+              + `<ul class="business-services">${serviceItems}</ul>`
+              + `</article>`
+            );
+          })
+          .join("");
+      };
+
+      const renderDayStrip = (weekDays, state) => {
+        dayStrip.innerHTML = weekDays
+          .map((day) => {
+            const selectedClass = day.is_selected ? " is-selected" : "";
+            const dayClass = `day-pill day-pill--${escapeHtml(day.status)}${selectedClass}`;
+            const href = `${scheduleUrl}?${queryStringFor({
+              business_id: state.business_id,
+              service_id: state.service_id,
+              date: day.date,
+            })}`;
+            return (
+              `<a class="${dayClass}" href="${href}" data-date="${escapeHtml(day.date)}">`
+              + `<span class="day-pill-weekday">${escapeHtml(day.weekday)}</span>`
+              + `<span class="day-pill-day">${escapeHtml(day.day_number)}</span>`
+              + `<span class="day-pill-status">${escapeHtml(day.status_label)}</span>`
+              + `</a>`
+            );
+          })
+          .join("");
+      };
+
+      const renderNextSlots = (nextSlots) => {
+        if (nextSlots.length === 0) {
+          return (
+            `<p class="next-slot-empty">`
+            + `No open slots remain this week for the selected service.`
+            + `</p>`
+          );
+        }
+
+        const rows = nextSlots
+          .map(
+            (slot) =>
+              `<p class="next-slot-item"><strong>${escapeHtml(slot.day_label)}</strong> · ${escapeHtml(slot.time_label)}</p>`,
+          )
+          .join("");
+        return `<div class="next-slot-list">${rows}</div>`;
+      };
+
+      const renderTimelineCells = (slots, key) =>
+        slots
+          .map((slot) => {
+            const stateClass = slot[key] ? "is-free" : "is-busy";
+            return (
+              `<span class="timeline-cell ${stateClass}" title="${escapeHtml(slot.label)}"></span>`
+            );
+          })
+          .join("");
+
+      const renderSlotGrid = (slots, state) =>
+        slots
+          .map((slot) => {
+            if (slot.bookable) {
+              return (
+                `<form class="inline-form" method="post" action="${bookAppointmentUrl}">`
+                + `<input type="hidden" name="business_id" value="${escapeHtml(state.business_id)}" />`
+                + `<input type="hidden" name="service_id" value="${escapeHtml(state.service_id)}" />`
+                + `<input type="hidden" name="date" value="${escapeHtml(state.date)}" />`
+                + `<input type="hidden" name="slot_start" value="${escapeHtml(slot.start_time)}" />`
+                + `<button class="demo-slot is-available" type="submit">`
+                + `<span>${escapeHtml(slot.label)}</span>`
+                + `<small>${escapeHtml(slot.status_label)}</small>`
+                + `</button>`
+                + `</form>`
+              );
+            }
+
+            const reasonClass = String(slot.reason || "").replace(/_/g, "-");
+            return (
+              `<button class="demo-slot is-unavailable is-${escapeHtml(reasonClass)}" type="button" disabled>`
+              + `<span>${escapeHtml(slot.label)}</span>`
+              + `<small>${escapeHtml(slot.status_label)}</small>`
+              + `</button>`
+            );
+          })
+          .join("");
+
+      const setLoading = (isLoading) => {
+        detailPanel.classList.toggle("is-loading", isLoading);
+      };
+
+      const stateFromControls = () => ({
+        business_id: businessSelect.value || businesses[0]?.id || "",
+        service_id: serviceSelect.value || "",
+        date: dateInput.value || fallbackToday,
+      });
+
+      const applyScheduleData = (data, options = {}) => {
+        const selectedBusinessId = data.selected_business?.id || businesses[0]?.id || "";
+        businessSelect.value = selectedBusinessId;
+        const resolvedServiceId = renderServiceOptions(
+          selectedBusinessId,
+          data.selected_service?.id || serviceSelect.value,
+        );
+
+        const state = {
+          business_id: selectedBusinessId,
+          service_id: resolvedServiceId,
+          date: data.selected_date || fallbackToday,
+        };
+
+        dateInput.value = state.date;
+        selectedBusinessTitle.textContent = data.selected_business?.name || "";
+        selectedServiceMeta.textContent = `${data.selected_service?.name || ""} · ${data.selected_service?.duration || ""} minutes · Time range ${data.selected_time_range || ""}`;
+        selectedDateMeta.textContent = `${data.selected_date_human || ""} · ${data.available_count || 0} available · ${data.unavailable_count || 0} unavailable`;
+
+        renderBusinessCards(selectedBusinessId);
+        renderDayStrip(data.week_days || [], state);
+        nextSlotBody.innerHTML = renderNextSlots(data.next_available_slots || []);
+
+        const slots = data.day_slots || [];
+        const hasSlots = slots.length > 0;
+
+        timelinePanel.classList.toggle("is-hidden", !hasSlots);
+        slotLegend.classList.toggle("is-hidden", !hasSlots);
+        slotGrid.classList.toggle("is-hidden", !hasSlots);
+        closedMessage.classList.toggle("is-hidden", hasSlots);
+
+        timelineBusinessCells.innerHTML = hasSlots
+          ? renderTimelineCells(slots, "business_free")
+          : "";
+        timelineUserCells.innerHTML = hasSlots
+          ? renderTimelineCells(slots, "user_free")
+          : "";
+        slotGrid.innerHTML = hasSlots
+          ? renderSlotGrid(slots, state)
+          : "";
+
+        if (options.updateHistory !== false) {
+          const nextUrl = `${scheduleUrl}?${queryStringFor(state)}`;
+          if (options.replaceHistory) {
+            window.history.replaceState(state, "", nextUrl);
+          } else {
+            window.history.pushState(state, "", nextUrl);
+          }
+        }
+      };
+
+      const loadScheduleData = async (state, options = {}) => {
+        if (!state.business_id) {
+          return;
+        }
+
+        if (inFlightController) {
+          inFlightController.abort();
+        }
+
+        const controller = new AbortController();
+        inFlightController = controller;
+        setLoading(true);
+
+        try {
+          const response = await fetch(
+            `${scheduleDataUrl}?${queryStringFor(state)}`,
+            {
+              headers: {
+                "X-Requested-With": "XMLHttpRequest",
+                Accept: "application/json",
+              },
+              signal: controller.signal,
+            },
+          );
+          if (!response.ok) {
+            throw new Error(`Request failed: ${response.status}`);
+          }
+
+          const payload = await response.json();
+          applyScheduleData(payload, options);
+        } catch (error) {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          window.location.href = `${scheduleUrl}?${queryStringFor(state)}`;
+        } finally {
+          if (inFlightController === controller) {
+            inFlightController = null;
+            setLoading(false);
+          }
+        }
+      };
+
+      const loadFromControls = () => {
+        const nextState = stateFromControls();
+        loadScheduleData(nextState, { updateHistory: true });
+      };
+
+      if (updateButton) {
+        updateButton.classList.add("is-hidden");
+      }
+
+      controlsForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        loadFromControls();
+      });
+
+      businessSelect.addEventListener("change", () => {
+        const newBusinessId = businessSelect.value;
+        renderServiceOptions(newBusinessId, "");
+        loadFromControls();
+      });
+
+      serviceSelect.addEventListener("change", () => {
+        loadFromControls();
+      });
+
+      dateInput.addEventListener("change", () => {
+        loadFromControls();
+      });
+
+      dayStrip.addEventListener("click", (event) => {
+        const dayPill = event.target.closest("a.day-pill[data-date]");
+        if (!dayPill) {
+          return;
+        }
+
+        event.preventDefault();
+        const targetDate = dayPill.getAttribute("data-date");
+        if (!targetDate) {
+          return;
+        }
+
+        dateInput.value = targetDate;
+        loadFromControls();
+      });
+
+      window.addEventListener("popstate", () => {
+        const params = new URLSearchParams(window.location.search);
+        const state = {
+          business_id: params.get("business_id") || businessSelect.value,
+          service_id: params.get("service_id") || serviceSelect.value,
+          date: params.get("date") || dateInput.value || fallbackToday,
+        };
+        loadScheduleData(state, { updateHistory: false });
+      });
+    })();
+  </script>
 {% endblock %}

--- a/Secretariat/templates/base.html
+++ b/Secretariat/templates/base.html
@@ -34,6 +34,10 @@
         box-sizing: border-box;
       }
 
+      .is-hidden {
+        display: none !important;
+      }
+
       body {
         margin: 0;
         min-height: 100vh;
@@ -597,6 +601,15 @@
         margin-top: var(--space-1);
       }
 
+      #schedule-detail-panel {
+        transition: opacity 140ms ease-in-out;
+      }
+
+      #schedule-detail-panel.is-loading {
+        opacity: 0.58;
+        pointer-events: none;
+      }
+
       .day-strip {
         display: grid;
         grid-template-columns: repeat(7, minmax(0, 1fr));
@@ -611,6 +624,22 @@
         background: var(--surface);
         display: grid;
         gap: 4px;
+        cursor: pointer;
+        transition:
+          border-color 140ms ease-in-out,
+          box-shadow 140ms ease-in-out,
+          transform 140ms ease-in-out;
+      }
+
+      .day-pill:hover {
+        border-color: #981e3260;
+        box-shadow: 0 6px 16px #0f172a12;
+        transform: translateY(-1px);
+      }
+
+      .day-pill:focus-visible {
+        outline: 2px solid #0f766e;
+        outline-offset: 2px;
       }
 
       .day-pill.is-selected {
@@ -660,6 +689,62 @@
         gap: 12px;
       }
 
+      .timeline-panel {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        background: #f8fafc;
+        padding: 14px;
+        display: grid;
+        gap: 10px;
+      }
+
+      .timeline-title {
+        margin: 0;
+        color: var(--text-primary);
+        font-size: 14px;
+        line-height: 20px;
+        font-weight: 600;
+      }
+
+      .timeline-row {
+        display: grid;
+        grid-template-columns: 72px 1fr;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .timeline-label {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 12px;
+        line-height: 16px;
+        font-weight: 600;
+      }
+
+      .timeline-cells {
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(0, 1fr);
+        gap: 4px;
+      }
+
+      .timeline-cell {
+        height: 10px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: #ffffff;
+      }
+
+      .timeline-cell.is-free {
+        border-color: #16a34a66;
+        background: #dcfce7;
+      }
+
+      .timeline-cell.is-busy {
+        border-color: #dc262655;
+        background: #fee2e2;
+      }
+
       .legend-item {
         display: inline-flex;
         align-items: center;
@@ -691,6 +776,56 @@
         background: #475569;
       }
 
+      .legend-dot--slot-available {
+        background: #16a34a;
+      }
+
+      .legend-dot--slot-user-busy {
+        background: #1d4ed8;
+      }
+
+      .legend-dot--slot-business-busy {
+        background: #dc2626;
+      }
+
+      .legend-dot--slot-both-busy {
+        background: #9a3412;
+      }
+
+      .next-slot-panel {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        background: #f8fafc;
+        padding: 14px;
+      }
+
+      .next-slot-title {
+        margin: 0 0 8px;
+        color: var(--text-primary);
+        font-size: 14px;
+        line-height: 20px;
+        font-weight: 600;
+      }
+
+      .next-slot-list {
+        display: grid;
+        gap: 6px;
+      }
+
+      .next-slot-item {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 14px;
+        line-height: 20px;
+      }
+
+      .next-slot-empty {
+        margin: 0;
+        color: var(--muted);
+        font-size: 14px;
+        line-height: 20px;
+      }
+
       .demo-slot-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
@@ -698,6 +833,7 @@
       }
 
       .demo-slot {
+        width: 100%;
         min-height: 62px;
         border-radius: 12px;
         border: 1px solid var(--border);
@@ -724,6 +860,22 @@
       .demo-slot.is-available {
         border-color: #16a34a66;
         background: #f0fdf4;
+        cursor: pointer;
+        transition:
+          border-color 140ms ease-in-out,
+          box-shadow 140ms ease-in-out,
+          transform 140ms ease-in-out;
+      }
+
+      .demo-slot.is-available:hover {
+        border-color: #16a34aaa;
+        box-shadow: 0 8px 20px #16a34a1f;
+        transform: translateY(-1px);
+      }
+
+      .demo-slot.is-available:focus-visible {
+        outline: 2px solid #15803d;
+        outline-offset: 2px;
       }
 
       .demo-slot.is-unavailable {
@@ -734,6 +886,36 @@
       .demo-slot.is-unavailable span,
       .demo-slot.is-unavailable small {
         color: #991b1b;
+      }
+
+      .demo-slot.is-user-busy {
+        border-color: #1d4ed855;
+        background: #eff6ff;
+      }
+
+      .demo-slot.is-user-busy span,
+      .demo-slot.is-user-busy small {
+        color: #1e3a8a;
+      }
+
+      .demo-slot.is-business-busy {
+        border-color: #dc262655;
+        background: #fef2f2;
+      }
+
+      .demo-slot.is-business-busy span,
+      .demo-slot.is-business-busy small {
+        color: #991b1b;
+      }
+
+      .demo-slot.is-both-busy {
+        border-color: #9a341255;
+        background: #fff7ed;
+      }
+
+      .demo-slot.is-both-busy span,
+      .demo-slot.is-both-busy small {
+        color: #7c2d12;
       }
 
       .event-grid {

--- a/tests/test_app_flow.py
+++ b/tests/test_app_flow.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import unittest
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import patch
 
 from Secretariat import (
+    _build_business_day_slots,
     _google_event_time_label,
     _home_week_columns,
     _parse_google_datetime,
+    _selected_business,
+    _selected_business_service,
     create_app,
 )
 
@@ -49,6 +52,91 @@ class TimestampFormattingTests(unittest.TestCase):
         self.assertEqual(label, "Mon, Feb 23 · All day")
 
 
+class SlotIntersectionTests(unittest.TestCase):
+    """Validate business/user availability intersection slot modeling."""
+
+    def setUp(self) -> None:
+        """Load one business/service pair used across slot tests."""
+        self.business = _selected_business("crimson-cuts")
+        self.service = _selected_business_service(self.business, "fade-cut")
+        self.chosen_date = date(2026, 2, 23)
+
+    def _slot(
+        self,
+        start_time: str,
+        user_busy: list[tuple[datetime, datetime]],
+    ) -> dict[str, object]:
+        """Return one slot from generated day slots."""
+        day_slots = _build_business_day_slots(
+            self.business,
+            self.service,
+            self.chosen_date,
+            user_busy_periods=user_busy,
+        )
+        return next(
+            slot for slot in day_slots if slot["start_time"] == start_time
+        )
+
+    def test_slot_marks_user_busy_reason(self) -> None:
+        """Mark slot unavailable when only the user is busy."""
+        slot = self._slot(
+            "11:00",
+            [
+                (
+                    datetime(2026, 2, 23, 11, 0),
+                    datetime(2026, 2, 23, 11, 30),
+                )
+            ],
+        )
+
+        self.assertTrue(slot["business_free"])
+        self.assertFalse(slot["user_free"])
+        self.assertFalse(slot["bookable"])
+        self.assertEqual(slot["reason"], "user_busy")
+        self.assertEqual(slot["status_label"], "Unavailable - You are busy")
+
+    def test_slot_marks_business_busy_reason(self) -> None:
+        """Mark slot unavailable when only mock business is busy."""
+        slot = self._slot("10:00", [])
+
+        self.assertFalse(slot["business_free"])
+        self.assertTrue(slot["user_free"])
+        self.assertFalse(slot["bookable"])
+        self.assertEqual(slot["reason"], "business_busy")
+        self.assertEqual(
+            slot["status_label"],
+            "Unavailable - Business is busy",
+        )
+
+    def test_slot_marks_both_busy_reason(self) -> None:
+        """Mark slot unavailable as both-busy when both sides conflict."""
+        slot = self._slot(
+            "10:00",
+            [
+                (
+                    datetime(2026, 2, 23, 10, 0),
+                    datetime(2026, 2, 23, 10, 30),
+                )
+            ],
+        )
+
+        self.assertFalse(slot["business_free"])
+        self.assertFalse(slot["user_free"])
+        self.assertFalse(slot["bookable"])
+        self.assertEqual(slot["reason"], "both_busy")
+        self.assertEqual(slot["status_label"], "Unavailable - Both busy")
+
+    def test_slot_marks_available_as_bookable(self) -> None:
+        """Keep slot bookable when user and business are both free."""
+        slot = self._slot("11:00", [])
+
+        self.assertTrue(slot["business_free"])
+        self.assertTrue(slot["user_free"])
+        self.assertTrue(slot["bookable"])
+        self.assertEqual(slot["reason"], "available")
+        self.assertEqual(slot["status_label"], "Available (both free)")
+
+
 class RouteFlowTests(unittest.TestCase):
     """Validate route behavior for signed-out and signed-in sessions."""
 
@@ -69,6 +157,29 @@ class RouteFlowTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Sign in with Google to continue.", response.data)
+
+    def test_schedule_data_returns_json_payload(self) -> None:
+        """Expose async schedule payload for client-side updates."""
+        self._seed_signed_in_session()
+        with patch(
+            "Secretariat._load_user_busy_periods_for_window",
+            return_value=[],
+        ):
+            response = self.client.get(
+                "/schedule/data?business_id=crimson-cuts&"
+                "service_id=fade-cut&date=2026-02-23",
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIsInstance(payload, dict)
+        if not isinstance(payload, dict):
+            return
+        self.assertIn("day_slots", payload)
+        self.assertIn("week_days", payload)
+        self.assertIn("selected_business", payload)
+        self.assertEqual(payload["selected_business"]["id"], "crimson-cuts")
 
     def test_index_redirects_to_home_when_signed_in(self) -> None:
         """Redirect signed-in users away from landing page."""
@@ -119,6 +230,24 @@ class RouteFlowTests(unittest.TestCase):
         self.assertIn(b"Prev", response.data)
         self.assertIn(b"Next", response.data)
 
+    def test_schedule_shows_intersection_overlay_labels(self) -> None:
+        """Render schedule overlay labels and next-slot guidance text."""
+        self._seed_signed_in_session()
+        with patch(
+            "Secretariat._load_user_busy_periods_for_window",
+            return_value=[],
+        ):
+            response = self.client.get(
+                "/schedule?business_id=crimson-cuts&service_id=fade-cut"
+                "&date=2026-02-23",
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Availability Overlay", response.data)
+        self.assertIn(b"Next 3 available times", response.data)
+        self.assertIn(b"Unavailable - Business is busy", response.data)
+
     def test_oauth_callback_missing_state_shows_error(self) -> None:
         """Display an OAuth error when callback state is unavailable."""
         response = self.client.get("/oauth2callback", follow_redirects=True)
@@ -139,6 +268,100 @@ class RouteFlowTests(unittest.TestCase):
         self.assertEqual(response.headers.get("Location"), "/")
         with self.client.session_transaction() as session:
             self.assertNotIn("credentials", session)
+
+    def test_book_appointment_creates_google_event(self) -> None:
+        """Book an available slot and redirect back to home."""
+        self._seed_signed_in_session()
+        payload = {
+            "business_id": "crimson-cuts",
+            "service_id": "fade-cut",
+            "date": "2026-02-23",
+            "slot_start": "09:00",
+        }
+        with (
+            patch(
+                "Secretariat._load_user_busy_periods_for_window",
+                return_value=[],
+            ),
+            patch(
+                "Secretariat._create_google_primary_event",
+                return_value={"id": "event-1"},
+            ) as mock_create_event,
+        ):
+            response = self.client.post(
+                "/appointments",
+                data=payload,
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers.get("Location"), "/home")
+        mock_create_event.assert_called_once()
+
+    def test_book_appointment_rejects_stale_slot_conflict(self) -> None:
+        """Reject stale booking attempts when the slot is no longer free."""
+        self._seed_signed_in_session()
+        payload = {
+            "business_id": "crimson-cuts",
+            "service_id": "fade-cut",
+            "date": "2026-02-23",
+            "slot_start": "09:00",
+        }
+        busy_periods = [
+            (
+                datetime(2026, 2, 23, 9, 0),
+                datetime(2026, 2, 23, 9, 30),
+            )
+        ]
+        with (
+            patch(
+                "Secretariat._load_user_busy_periods_for_window",
+                return_value=busy_periods,
+            ),
+            patch(
+                "Secretariat._create_google_primary_event"
+            ) as mock_create_event,
+        ):
+            response = self.client.post(
+                "/appointments",
+                data=payload,
+                follow_redirects=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            b"Selected slot is no longer available. Pick another time.",
+            response.data,
+        )
+        mock_create_event.assert_not_called()
+
+    def test_book_appointment_rejects_invalid_slot_value(self) -> None:
+        """Reject malformed slot values before calendar insertion."""
+        self._seed_signed_in_session()
+        payload = {
+            "business_id": "crimson-cuts",
+            "service_id": "fade-cut",
+            "date": "2026-02-23",
+            "slot_start": "not-a-clock",
+        }
+        with (
+            patch(
+                "Secretariat._load_user_busy_periods_for_window",
+                return_value=[],
+            ),
+            patch(
+                "Secretariat._create_google_primary_event"
+            ) as mock_create_event,
+        ):
+            response = self.client.post(
+                "/appointments",
+                data=payload,
+                follow_redirects=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Please choose a valid time slot.", response.data)
+        mock_create_event.assert_not_called()
 
 
 class HomeWeekColumnsTests(unittest.TestCase):


### PR DESCRIPTION
**ONLY MERGE IF APPROVED, THIS IS JUST TESTING/FUN. ONLY MERGE IF YOU APPROVE**

This PR implements the core scheduling MVP: mock business availability + real user Google Calendar with actual booking writes to the user’s primary calendar.

It also upgrades the scheduling UX so selecting business/service/date/day is handled asynchronously (no full page reload), and adds an availability overlay that shows why each slot is blocked.


What This Enables on Localhost
After signing in with Google and selecting mock business/service/date:

/schedule shows both mock business availability and your real calendar conflicts at the same time.
Slots explain exactly why unavailable.
Changing business/service/date/day updates in place without full page reload.
Clicking an available slot books it.
Booking writes to your Google primary calendar.
/home reflects the updated calendar state.
Why This Ended Up as a Large Change
Most added lines are from:

Frontend async rendering logic (state + fetch + history + fallback).
New UI components/styling (overlay, legend, next-slot panel, status states).
Defensive server-side validation/recheck for booking correctness.
Expanded tests for new behaviors.
The size is mostly feature-complete UX + reliability, not unnecessary complexity.


**ONLY MERGE IF APPROVED, THIS IS JUST TESTING/FUN. ONLY MERGE IF YOU APPROVE**